### PR TITLE
remove deprecated `bottle :unneeded`

### DIFF
--- a/Formula/helm-docs.rb
+++ b/Formula/helm-docs.rb
@@ -6,7 +6,6 @@ class HelmDocs < Formula
   desc "Automatically generate markdown documentation for helm charts"
   homepage "https://github.com/norwoodj/helm-docs"
   version "1.5.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/norwoodj/helm-docs/releases/download/v1.5.0/helm-docs_1.5.0_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
When installing or updating something with Homebrew, one gets the following warning:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the norwoodj/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/norwoodj/homebrew-tap/Formula/helm-docs.rb:9
  ```

This is due to the fact, that `bottle :unneeded` is deprecated without a replacement:
https://github.com/Homebrew/brew/pull/11239

After this PR the corresponding line will be removed from the formula.