### PR TITLE
Remove deprecated "bottle :unneeded"

### DIFF
--- a/Formula/helm-docs.rb
+++ b/Formula/helm-docs.rb
@@ -6,7 +6,6 @@ class HelmDocs < Formula
   desc "Automatically generate markdown documentation for helm charts"
   homepage "https://github.com/norwoodj/helm-docs"
   version "1.5.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/norwoodj/helm-docs/releases/download/v1.5.0/helm-docs_1.5.0_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
I know that [this will be fixed after releasing a new version of `helm-docs` using the latest version of `goreleaser`](https://github.com/norwoodj/helm-docs/issues/115#issuecomment-991712753), but before that'll happen, it would be nice to get rid of this annoying warning thrown by Homebrew.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the norwoodj/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/norwoodj/homebrew-tap/Formula/helm-docs.rb:9
```