### PR TITLE
Update the homebrew tap to use 1.7.0

### DIFF
--- a/Formula/helm-docs.rb
+++ b/Formula/helm-docs.rb
@@ -5,20 +5,20 @@
 class HelmDocs < Formula
   desc "Automatically generate markdown documentation for helm charts"
   homepage "https://github.com/norwoodj/helm-docs"
-  version "1.6.0"
+  version "1.7.0"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/norwoodj/helm-docs/releases/download/v1.6.0/helm-docs_1.6.0_Darwin_arm64.tar.gz"
-      sha256 "cadec8486b39fedb6b55df52a73cc9dc61ea28406dec9ecd11aeeb6f597ee7fd"
+      url "https://github.com/norwoodj/helm-docs/releases/download/v1.7.0/helm-docs_1.7.0_Darwin_arm64.tar.gz"
+      sha256 "51ce168e3af2dfde5ccbeafd277d9c77cf004544759882b5e3438448d84d6e89"
 
       def install
         bin.install "helm-docs"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/norwoodj/helm-docs/releases/download/v1.6.0/helm-docs_1.6.0_Darwin_x86_64.tar.gz"
-      sha256 "e4352245ff91d21aa8c3c69e0114ed1f08a4ac41dd04e6543a8570dda8c627a7"
+      url "https://github.com/norwoodj/helm-docs/releases/download/v1.7.0/helm-docs_1.7.0_Darwin_x86_64.tar.gz"
+      sha256 "e34b4918ad92c6e553130029895aefc76a353f6ea7d968bbdf8037305dd22313"
 
       def install
         bin.install "helm-docs"
@@ -28,24 +28,24 @@ class HelmDocs < Formula
 
   on_linux do
     if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://github.com/norwoodj/helm-docs/releases/download/v1.6.0/helm-docs_1.6.0_Linux_armv6.tar.gz"
-      sha256 "c1323f21b785c00e79d0db51316ab3c2ea8af3512c963033f06cc4f3c4cc12de"
+      url "https://github.com/norwoodj/helm-docs/releases/download/v1.7.0/helm-docs_1.7.0_Linux_armv6.tar.gz"
+      sha256 "a75fbf614e346d69864e527fd845ee07c2dd26cbd968d23ebffbadcb2dcd1b13"
 
       def install
         bin.install "helm-docs"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/norwoodj/helm-docs/releases/download/v1.6.0/helm-docs_1.6.0_Linux_x86_64.tar.gz"
-      sha256 "286723d931c18581fc324985cb96e9cce639e521fa63b57ac04ebe9d497e60fb"
+      url "https://github.com/norwoodj/helm-docs/releases/download/v1.7.0/helm-docs_1.7.0_Linux_x86_64.tar.gz"
+      sha256 "b39ad34acd03256317692e5c671847d6f12bcd6c92adf05b3df83363d1dac20f"
 
       def install
         bin.install "helm-docs"
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/norwoodj/helm-docs/releases/download/v1.6.0/helm-docs_1.6.0_Linux_arm64.tar.gz"
-      sha256 "cb35cff92b7a9f0ea16cafaa187ec3ab4238442725d2c3aacb0cc4fa40131d23"
+      url "https://github.com/norwoodj/helm-docs/releases/download/v1.7.0/helm-docs_1.7.0_Linux_arm64.tar.gz"
+      sha256 "8e99abd3c773d46bbfcbeb33d2a857b6a09a1e258ac205acf27bfcc46bdb5895"
 
       def install
         bin.install "helm-docs"


### PR DESCRIPTION
Updating the versions of helm-docs to use latest 1.7.0.